### PR TITLE
Convert to the csr matrix and add dataset_id.

### DIFF
--- a/python/1-qc.py
+++ b/python/1-qc.py
@@ -290,6 +290,18 @@ filtered_adata.obs['is_primary'] = (
 # Update adata
 adata = filtered_adata
 
+# CSC to CSR
+if sp.issparse(adata.X):
+    if isinstance(adata.X, sp.csc_matrix):
+        adata.X = adata.X.tocsr()
+        print("adata.X has been converted from CSC to CSR format.")
+    else:
+        print("adata.X is not in CSC format, no conversion needed.")
+else:
+    print("adata.X is not a sparse matrix.")
+
+# Add a new column 'dataset_id' to adata.obs with the value from args.source_id
+adata.obs['dataset_id'] = args.source_id
 
 # Print basic information after preprocessing
 print(f"Post-processing number of genes: {adata.shape[1]}")


### PR DESCRIPTION
1. Convert to the csr matrix when quality control.
2. Add "dataset_id" to adata.obs when quality control.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the quality control process by converting adata.X to CSR format if it is in CSC format and add a new 'dataset_id' column to adata.obs.

New Features:
- Add a new column 'dataset_id' to adata.obs with the value from args.source_id during quality control.

Enhancements:
- Convert adata.X from CSC to CSR format if it is a sparse matrix in CSC format during quality control.

<!-- Generated by sourcery-ai[bot]: end summary -->